### PR TITLE
[b/134796047] Correlate price change and news sentiment

### DIFF
--- a/crypto-ingest/README.md
+++ b/crypto-ingest/README.md
@@ -72,5 +72,12 @@ You should be able to see 2 files generated for each currency:
 * prices_$CURRENCY_$DATE.csv
 * news_$CURRENCY_$DATE.csv
 
+Copy the files to GCS so that Dataflow can directly read the input files:
+
+```bash
+# -m enables parallel operation 
+gsutil -m cp *.csv gs://dataflow-eou-diary/
+```
+
 Collected data might be redundant from day to day, merging and cleaning up need to be done in the
  beginning of any pipeline using these data.

--- a/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/ClusterKey.java
+++ b/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/ClusterKey.java
@@ -1,0 +1,40 @@
+package com.google.dataflow.eou.diary.crypto.model;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import javax.xml.bind.DatatypeConverter;
+
+/**
+ * A helper class to build deterministic serializable key for Beam grouping since Java serialization
+ * is not deterministic with respect to Object.equals(java.lang.Object) for all types.
+ */
+@AutoValue
+public abstract class ClusterKey implements Serializable {
+
+  public static ClusterKey create(Currency currency, String date) {
+    return new AutoValue_ClusterKey(currency, date);
+  }
+
+  public static ClusterKey deserialize(List<String> key) {
+    return create(Currency.fromCode(key.get(0)), key.get(1));
+  }
+
+  public List<String> serialize() {
+    return Arrays
+        .asList(currency().toString(), date());
+  }
+
+  public ClusterKey truncateDateToDay() {
+    return create(currency(),
+        DatatypeConverter.parseDateTime(date()).toInstant().truncatedTo(ChronoUnit.DAYS)
+            .toString());
+  }
+
+  public abstract Currency currency();
+
+  // ISO-8061 format.
+  public abstract String date();
+}

--- a/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/Currency.java
+++ b/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/Currency.java
@@ -1,23 +1,94 @@
 package com.google.dataflow.eou.diary.crypto.model;
 
 /**
- * Enums of crypto currencies.
+ * Enums of crypto currency codes.
  */
 public enum Currency {
   // A default value that doesn't represent any real currency.
-  DEFAULT(""),
+  DEFAULT,
 
-  // Bit coin.
-  BTC("btc");
+  // bitcoin
+  BTC,
 
-  private final String code;
+  // litecoin
+  LTC,
 
-  Currency(String code) {
-    this.code = code;
-  }
+  // namecoin
+  NMC,
 
-  @Override
-  public String toString() {
-    return code;
+  // peercoin
+  PPC,
+
+  // dogecoin
+  DOGE,
+
+  // gridcoin
+  GRC,
+
+  // primecoin
+  XPM,
+
+  // ripple
+  XRP,
+
+  // nxt
+  NXT,
+
+  // auroracoin
+  AUR,
+
+  // dash
+  DASH,
+
+  // neo
+  NEO,
+
+  // monero
+  XMR,
+
+  //nem
+  XEM,
+
+  // titcoin
+  TIT,
+
+  // verge
+  XVG,
+
+  // stellar
+  XLM,
+
+  //vertcoin
+  VTC,
+
+  //ether
+  ETH,
+
+  //ethereumclassic
+  ETC,
+
+  //tether
+  USDT,
+
+  //zcash
+  ZEC,
+
+  //bitcoincash
+  BCH,
+
+  //eos.io
+  EOS;
+
+  /**
+   * Returns the enum of a crypto currency from its code. Code is case-insensitive. If a code is not
+   * valid or supported, returns the default currency enum. Consumers should ignore any default
+   * currency enum returned.
+   */
+  public static Currency fromCode(String code) {
+    try {
+      return Currency.valueOf(code.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return Currency.DEFAULT;
+    }
   }
 }

--- a/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/NewsSentiment.java
+++ b/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/NewsSentiment.java
@@ -1,0 +1,32 @@
+package com.google.dataflow.eou.diary.crypto.model;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import java.time.Instant;
+
+@AutoValue
+public abstract class NewsSentiment implements Serializable {
+
+  private static final NewsSentiment DEFAULT = NewsSentiment
+      .create(ClusterKey.create(Currency.DEFAULT,
+          Instant.EPOCH.toString()), 0.0, 0.0, 0.0, 0.0);
+
+  public static NewsSentiment create(ClusterKey clusterKey, double neg, double neu, double pos,
+      double compound) {
+    return new AutoValue_NewsSentiment(clusterKey, neg, neu, pos, compound);
+  }
+
+  public static NewsSentiment getDefault() {
+    return DEFAULT;
+  }
+
+  public abstract ClusterKey clusterKey();
+
+  public abstract double neg();
+
+  public abstract double neu();
+
+  public abstract double pos();
+
+  public abstract double compound();
+}

--- a/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/Price.java
+++ b/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/Price.java
@@ -11,17 +11,20 @@ import java.util.Date;
 @AutoValue
 public abstract class Price implements Serializable {
 
-  private static final Price DEFAULT = create(Date.from(Instant.EPOCH), 0.0, 0.0, 0.0, 0.0, 0l, 0l,
-      Currency.DEFAULT);
+  private static final Price DEFAULT = create(Currency.DEFAULT, Date.from(Instant.EPOCH), 0.0, 0.0,
+      0.0, 0.0, 0l, 0l);
 
-  public static Price create(Date date, double open, double high, double low, double close,
-      long volume, long marketCap, Currency currency) {
-    return new AutoValue_Price(date, open, high, low, close, volume, marketCap, currency);
+  public static Price create(Currency currency, Date date, double open, double high, double low,
+      double close,
+      long volume, long marketCap) {
+    return new AutoValue_Price(currency, date, open, high, low, close, volume, marketCap);
   }
 
   public static Price getDefault() {
     return DEFAULT;
   }
+
+  public abstract Currency currency();
 
   public abstract Date date();
 
@@ -36,6 +39,4 @@ public abstract class Price implements Serializable {
   public abstract long volume();
 
   public abstract long marketCap();
-
-  public abstract Currency currency();
 }

--- a/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/PriceChange.java
+++ b/crypto-model/src/main/java/com/google/dataflow/eou/diary/crypto/model/PriceChange.java
@@ -6,9 +6,9 @@ import java.io.Serializable;
 @AutoValue
 public abstract class PriceChange implements Serializable {
 
-  public static PriceChange create(String dateTruncatedToDay, Change change, double priceDiffValue,
+  public static PriceChange create(ClusterKey clusterKey, Change change, double priceDiffValue,
       double priceDiffPercentile) {
-    return new AutoValue_PriceChange(dateTruncatedToDay, change, priceDiffValue,
+    return new AutoValue_PriceChange(clusterKey, change, priceDiffValue,
         priceDiffPercentile);
   }
 
@@ -43,8 +43,7 @@ public abstract class PriceChange implements Serializable {
     EQ
   }
 
-  // Using ISO-8061 format which can be parsed by java.time.Instant.
-  public abstract String dateTruncatedToDay();
+  public abstract ClusterKey clusterKey();
 
   public abstract Change change();
 

--- a/crypto-research-batch/README.md
+++ b/crypto-research-batch/README.md
@@ -101,3 +101,55 @@ dependencies {
   # Shows all Dataflow pipeline options
   ./gradlew run --args='--help=org.apache.beam.runners.dataflow.options.DataflowPipelineOptions'
   ```
+  
+  E.g., look up the options defined by CryptoResearchBatch:
+  
+  ```bash
+  ./gradlew run --args='--help=com.google.dataflow.eou.diary.crypto.CryptoResearchBatch$CryptoResearchBatchOptions'
+  ```
+  
+  An example output:
+  
+  ```
+  > Task :run
+  com.google.dataflow.eou.diary.crypto.CryptoResearchBatch$CryptoResearchBatchOptions:
+  
+    --correlationOutput=<String>
+      Default: gs://dataflow-eou-diary/correlation.csv
+      Path to the file to write price change and news sentiment correlation to
+    --currencyPriceChangeOutput=<String>
+      Default: gs://dataflow-eou-diary/price_change_output.csv
+      Path of the file to write price changes to
+    --currencyPriceInputFile=<String>
+      Default: gs://dataflow-eou-diary/prices_*.csv
+      Path of the file to read crypto currency prices from
+    --newsInputFile=<String>
+      Default: gs://dataflow-eou-diary/news_*.csv
+      Path of the file to read news articles from
+  
+  org.apache.beam.sdk.options.PipelineOptions:
+  
+    --jobName=<String>
+      Default: JobNameFactory
+      Name of the pipeline execution.It must match the regular expression
+      '[a-z]([-a-z0-9]{0,38}[a-z0-9])?'.It defaults to
+      ApplicationName-UserName-Date-RandomInteger
+    --optionsId=<long>
+      Default: AtomicLongFactory
+    --runner=<Class>
+      Default: DirectRunner
+      The pipeline runner that will be used to execute the pipeline. For
+      registered runners, the class name can be specified, otherwise the fully
+      qualified name needs to be specified.
+    --stableUniqueNames=<OFF | WARNING | ERROR>
+      Default: WARNING
+      Whether to check for stable unique names on each transform. This is
+      necessary to support updating of pipelines.
+    --tempLocation=<String>
+      A pipeline level default location for storing temporary files.
+    --userAgent=<String>
+      Default: UserAgentFactory
+      A user agent string describing the pipeline to external services. The format
+      should follow RFC2616. This option defaults to "[name]/[version]" where name
+      and version are properties of the Apache Beam release.
+  ```

--- a/crypto-research-batch/src/main/java/com/google/dataflow/eou/diary/crypto/CryptoResearchBatch.java
+++ b/crypto-research-batch/src/main/java/com/google/dataflow/eou/diary/crypto/CryptoResearchBatch.java
@@ -1,12 +1,15 @@
 package com.google.dataflow.eou.diary.crypto;
 
+import com.google.common.base.Joiner;
+import com.google.dataflow.eou.diary.crypto.model.ClusterKey;
 import com.google.dataflow.eou.diary.crypto.model.Currency;
+import com.google.dataflow.eou.diary.crypto.model.NewsSentiment;
 import com.google.dataflow.eou.diary.crypto.model.Price;
 import com.google.dataflow.eou.diary.crypto.model.PriceChange;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
+import javax.xml.bind.DatatypeConverter;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.metrics.Counter;
@@ -19,6 +22,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Filter;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.ProcessFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.transforms.join.CoGroupByKey;
@@ -42,117 +46,245 @@ public class CryptoResearchBatch {
      * file.
      */
     @Description("Path of the file to read crypto currency prices from")
-    @Default.String("gs://dataflow-eou-diary/btc_prices.csv")
+    @Default.String("gs://dataflow-eou-diary/prices_*.csv")
     String getCurrencyPriceInputFile();
 
     void setCurrencyPriceInputFile(String value);
 
     @Description("Path of the file to read news articles from")
-    @Default.String("gs://dataflow-eou-diary/btc_news.csv")
+    @Default.String("gs://dataflow-eou-diary/news_*.csv")
     String getNewsInputFile();
 
     void setNewsInputFile(String value);
 
     /**
-     * A general output location for the pipeline.
+     * A branching raw data output location for the pipeline.
      */
-    @Description("Path of the file to write to")
-    @Default.String("gs://dataflow-eou-diary/output")
-    String getOutput();
+    @Description("Path of the file to write price changes to")
+    @Default.String("gs://dataflow-eou-diary/output_price_change.csv")
+    String getCurrencyPriceChangeOutput();
 
-    void setOutput(String value);
+    void setCurrencyPriceChangeOutput(String value);
+
+    @Description("Path to the file to write price change and news sentiment correlation to")
+    @Default.String("gs://dataflow-eou-diary/output_correlation.csv")
+    String getCorrelationOutput();
+
+    void setCorrelationOutput(String value);
   }
 
-  public static class ClusterPriceByDay extends DoFn<Price, KV<String, Price>> {
+  public static ProcessFunction<String, Price> readPriceData = line -> {
+    String[] columns = line.split(",");
+    if (Currency.fromCode(columns[0]) == Currency.DEFAULT) {
+      return Price.getDefault();
+    }
+    try {
+      // The date read should be in ISO-8061 format.
+      return Price
+          .create(Currency.fromCode(columns[0]),
+              Date.from(DatatypeConverter.parseDateTime(columns[1]).toInstant()),
+              Double.valueOf(columns[2]),
+              Double.valueOf(columns[3]), Double.valueOf(columns[4]),
+              Double.valueOf(columns[5]), Long.valueOf(columns[6]),
+              Long.valueOf(columns[7]));
+    } catch (Exception e) {
+      logger.debug("Cannot parse the price data: %s", line);
+      return Price.getDefault();
+    }
+  };
+
+  public static ProcessFunction<String, NewsSentiment> readNewsData = line -> {
+    String[] columns = line.split(",");
+    if (Currency.fromCode(columns[0]) == Currency.DEFAULT) {
+      return NewsSentiment.getDefault();
+    }
+    try {
+      return NewsSentiment
+          .create(ClusterKey.create(Currency.fromCode(columns[0]), columns[1]),
+              Double.valueOf(columns[5]), Double.valueOf(columns[6]), Double.valueOf(columns[7]),
+              Double.valueOf(columns[8]));
+    } catch (Exception e) {
+      logger.debug("Cannot parse the news data: %s", line);
+      return NewsSentiment.getDefault();
+    }
+  };
+
+  public static ProcessFunction<Price, Price> forwardPriceDateByOneDay = price -> {
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTime(price.date());
+    calendar.add(Calendar.DATE, 1);
+    return Price
+        .create(price.currency(), calendar.getTime(), price.open(), price.high(),
+            price.low(),
+            price.close(), price.volume(), price.marketCap());
+  };
+
+  /**
+   * Cluster price values by a tuple/list as (date, currency). If there are duplicated values for
+   * the same (date, currency), the cluster would contain multiple price values with the same price.
+   * If there is no duplicate from input, each cluster should be singleton list.
+   */
+  public static class ClusterPriceByDay extends DoFn<Price, KV<List<String>, Price>> {
 
     private final Counter priceCount = Metrics.counter(ClusterPriceByDay.class, "priceCount");
 
     @ProcessElement
     public void processElement(ProcessContext c) {
       priceCount.inc();
-      c.output(KV.of(c.element().date().toInstant().truncatedTo(ChronoUnit.DAYS).toString(),
+      c.output(KV.of(
+          ClusterKey.create(c.element().currency(),
+              c.element().date().toInstant().toString()).truncateDateToDay().serialize(),
           c.element()));
+    }
+  }
+
+  public static class SerializeClusterKeyForPriceChange extends
+      DoFn<PriceChange, KV<List<String>, PriceChange>> {
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      c.output(KV.of(c.element().clusterKey().serialize(), c.element()));
+    }
+  }
+
+  public static class SerializeClusterKeyForNewsSentiment extends
+      DoFn<NewsSentiment, KV<List<String>, NewsSentiment>> {
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      c.output(KV.of(c.element().clusterKey().truncateDateToDay().serialize(), c.element()));
+    }
+  }
+
+  public static class CalculatePriceChangesByDay extends
+      DoFn<KV<List<String>, CoGbkResult>, PriceChange> {
+
+    private final TupleTag<Price> yesterdayPriceTag;
+    private final TupleTag<Price> todayPriceTag;
+
+    public CalculatePriceChangesByDay(TupleTag<Price> yesterdayPriceTag,
+        TupleTag<Price> todayPriceTag) {
+      this.yesterdayPriceTag = yesterdayPriceTag;
+      this.todayPriceTag = todayPriceTag;
+    }
+
+    @ProcessElement
+    public void processElement(
+        @Element KV<List<String>, CoGbkResult> consecutivePriceByDay,
+        OutputReceiver<PriceChange> out) {
+      // Just get the 1st value from the group to ignore duplicate items since
+      // (date, currency) should identify a unique price value in the history.
+      double yesterdayClose = consecutivePriceByDay.getValue().getAll(yesterdayPriceTag)
+          .iterator().next()
+          .close();
+      double todayClose = consecutivePriceByDay.getValue().getAll(todayPriceTag)
+          .iterator()
+          .next().close();
+      out.output(PriceChange
+          .create(ClusterKey.deserialize(consecutivePriceByDay.getKey()),
+              PriceChange.compare(yesterdayClose, todayClose),
+              PriceChange.diffInValue(yesterdayClose, todayClose),
+              PriceChange.diffInPercentile(yesterdayClose, todayClose)));
+    }
+  }
+
+  public static class CorrelateNewsSentimentByPriceChange extends
+      DoFn<KV<List<String>, CoGbkResult>, KV<PriceChange, NewsSentiment>> {
+
+    private final TupleTag<PriceChange> priceChangeTag;
+    private final TupleTag<NewsSentiment> newsSentimentTag;
+
+    public CorrelateNewsSentimentByPriceChange(TupleTag<PriceChange> priceChangeTag,
+        TupleTag<NewsSentiment> newsSentimentTag) {
+      this.priceChangeTag = priceChangeTag;
+      this.newsSentimentTag = newsSentimentTag;
+    }
+
+    @ProcessElement
+    public void processElement(@Element KV<List<String>, CoGbkResult> correlation,
+        OutputReceiver<KV<PriceChange, NewsSentiment>> out) {
+
+      PriceChange priceChange = correlation.getValue().getAll(priceChangeTag).iterator().next();
+      correlation.getValue().getAll(newsSentimentTag)
+          .forEach(newsSentiment -> out.output(KV.of(priceChange, newsSentiment)));
     }
   }
 
   static void runPipeline(CryptoResearchBatchOptions options) {
     Pipeline p = Pipeline.create(options);
 
-    PCollection<String> lines = p
-        .apply("ReadBtcPrices",
-            TextIO.read().from(options.getCurrencyPriceInputFile()));
-    PCollection<Price> prices = lines
+    PCollection<Price> prices = p
+        .apply("ReadCryptoCurrencyPrices",
+            TextIO.read().from(options.getCurrencyPriceInputFile()))
         .apply("ConvertCsvLineToPriceObject",
-            MapElements.into(TypeDescriptor.of(Price.class)).via((String line) -> {
-              String[] columns = line.split(",");
-              try {
-                // The date read should be in ISO-8061 format.
-                return Price
-                    .create(Date.from(Instant.parse(columns[0])), Double.valueOf(columns[1]),
-                        Double.valueOf(columns[2]), Double.valueOf(columns[3]),
-                        Double.valueOf(columns[4]), Long.valueOf(columns[5]),
-                        Long.valueOf(columns[6]),
-                        Currency.BTC);
-              } catch (Exception e) {
-                logger.debug("Cannot parse the date, not in ISO-8061: %s", columns[0]);
-                return Price.getDefault();
-              }
-            }));
-    PCollection<Price> parsablePrices = prices
+            MapElements.into(TypeDescriptor.of(Price.class)).via(readPriceData))
         .apply("FilterOutPricesWithoutValidData",
             Filter.by(price -> !price.equals(Price.getDefault())));
-    PCollection<Price> pricesWithDateMovedForwardOneDay = parsablePrices
-        .apply("ForwardDateByOneDayForEachPrice",
-            MapElements.into(TypeDescriptor.of(Price.class)).via((Price price) -> {
-              Calendar calendar = Calendar.getInstance();
-              calendar.setTime(price.date());
-              calendar.add(Calendar.DATE, 1);
-              return Price
-                  .create(calendar.getTime(), price.open(), price.high(), price.low(),
-                      price.close(), price.volume(), price.marketCap(), price.currency());
-            }));
 
-    final TupleTag<Price> oldPriceTag = new TupleTag<>();
-    final TupleTag<Price> newPriceTag = new TupleTag<>();
-
-    PCollection<KV<String, Price>> priceByYesterday = parsablePrices
+    PCollection<KV<List<String>, Price>> priceByYesterday = prices
         .apply("ClusterPricesByYesterday", ParDo.of(new ClusterPriceByDay()));
-    PCollection<KV<String, Price>> priceByToday = pricesWithDateMovedForwardOneDay
+    PCollection<KV<List<String>, Price>> priceByToday = prices
+        .apply("ForwardDateByOneDayForEachPrice",
+            MapElements.into(TypeDescriptor.of(Price.class)).via(forwardPriceDateByOneDay))
         .apply("ClusterPricesByToday", ParDo.of(new ClusterPriceByDay()));
-
-    PCollection<KV<String, CoGbkResult>> consecutivePricesByDay = KeyedPCollectionTuple
-        .of(oldPriceTag, priceByYesterday).and(newPriceTag, priceByToday).apply(
-            CoGroupByKey.create());
-
-    PCollection<PriceChange> priceChangeByDay = consecutivePricesByDay.
-        apply("FilterOutNonConsecutiveDays", Filter.by(consecutivePriceByDay ->
-            consecutivePriceByDay.getValue().getAll(oldPriceTag).iterator().hasNext()
-                && consecutivePriceByDay.getValue().getAll(newPriceTag).iterator().hasNext()))
+    final TupleTag<Price> yesterdayPriceTag = new TupleTag<>();
+    final TupleTag<Price> todayPriceTag = new TupleTag<>();
+    PCollection<PriceChange> priceChangeByDay = KeyedPCollectionTuple
+        .of(yesterdayPriceTag, priceByYesterday).and(todayPriceTag, priceByToday).apply(
+            CoGroupByKey.create()).
+            apply("FilterOutNonConsecutiveDays", Filter.by(consecutivePriceByDay ->
+                consecutivePriceByDay.getValue().getAll(yesterdayPriceTag).iterator().hasNext()
+                    && consecutivePriceByDay.getValue().getAll(todayPriceTag).iterator().hasNext()))
         .apply("CalculatePriceChangesByDay",
-            ParDo.of(new DoFn<KV<String, CoGbkResult>, PriceChange>() {
-              @ProcessElement
-              public void processElement(@Element KV<String, CoGbkResult> consecutivePriceByDay,
-                  OutputReceiver<PriceChange> out) {
-                double yesterdayClose = consecutivePriceByDay.getValue().getOnly(oldPriceTag)
-                    .close();
-                double todayClose = consecutivePriceByDay.getValue().getOnly(newPriceTag).close();
-                out.output(PriceChange.create(consecutivePriceByDay.getKey(),
-                    PriceChange.compare(yesterdayClose, todayClose),
-                    PriceChange.diffInValue(yesterdayClose, todayClose),
-                    PriceChange.diffInPercentile(yesterdayClose, todayClose)));
-              }
-            })
-
-        );
+            ParDo.of(new CalculatePriceChangesByDay(yesterdayPriceTag, todayPriceTag)));
 
     priceChangeByDay
-        .apply("FormatToString", MapElements.via(new SimpleFunction<PriceChange, String>() {
+        .apply("FormatPriceChangeToCsv", MapElements.via(new SimpleFunction<PriceChange, String>() {
           @Override
           public String apply(PriceChange input) {
-            return input.toString();
+            return Joiner.on(',')
+                .join(input.clusterKey().currency(), input.clusterKey().date(), input.change(),
+                    input.priceDiffValue(), input.priceDiffPercentile());
           }
         }))
-        .apply("Write", TextIO.write().to(options.getOutput()));
+        .apply("WriteFormattedPriceChange",
+            TextIO.write().to(options.getCurrencyPriceChangeOutput()));
+
+    PCollection<NewsSentiment> newsSentiment = p
+        .apply("ReadCryptoNewsSentiment", TextIO.read().from(options.getNewsInputFile()))
+        .apply("ConvertCsvLineToNewsSentimentObject",
+            MapElements.into(TypeDescriptor.of(NewsSentiment.class)).via(readNewsData))
+        .apply("FilterOutNewsSentimentWithoutValidData",
+            Filter.by(sentiment -> !sentiment.equals(NewsSentiment.getDefault())));
+
+    final TupleTag<PriceChange> priceChangeTag = new TupleTag<>();
+    final TupleTag<NewsSentiment> newsSentimentTag = new TupleTag<>();
+
+    PCollection<KV<PriceChange, NewsSentiment>> normalizedCorrelation = KeyedPCollectionTuple
+        .of(priceChangeTag, priceChangeByDay
+            .apply("SerializeClusterKeyForPriceChange",
+                ParDo.of(new SerializeClusterKeyForPriceChange())))
+        .and(newsSentimentTag, newsSentiment
+            .apply("SerializeClusterKeyForNewsSentiment",
+                ParDo.of(new SerializeClusterKeyForNewsSentiment()))).apply(CoGroupByKey.create())
+        .apply("FilterOutPriceChangeWithoutNews", Filter
+            .by(correlation -> correlation.getValue().getAll(priceChangeTag).iterator().hasNext()
+                && correlation.getValue().getAll(newsSentimentTag).iterator().hasNext()))
+        .apply("CorrelateNewsSentimentByPriceChange",
+            ParDo.of(new CorrelateNewsSentimentByPriceChange(priceChangeTag, newsSentimentTag)));
+
+    normalizedCorrelation.apply("FormatNormalizedCorrelationToCsv", MapElements.via(
+        new SimpleFunction<KV<PriceChange, NewsSentiment>, String>() {
+          @Override
+          public String apply(KV<PriceChange, NewsSentiment> input) {
+            return Joiner.on(',')
+                .join(input.getKey().clusterKey().currency(), input.getKey().clusterKey().date(),
+                    input.getKey().change(), input.getKey().priceDiffValue(),
+                    input.getKey().priceDiffPercentile(), input.getValue().neg(),
+                    input.getValue().neu(), input.getValue().pos(), input.getValue().compound());
+          }
+        })).apply("WriteFormattedPriceChangeAndNewsSentimentCorrelation",
+        TextIO.write().to(options.getCorrelationOutput()));
 
     p.run().waitUntilFinish();
   }


### PR DESCRIPTION
1. Added ClusterKey as (currency,date) w/ serialization/deserialization
methods to use as key for GBK transform in Beam.
2. Added NewsSentiment model to hold sentiment scores.
3. Updated READMEs.
4. Completed batch pipeline to find correlation between price change and
news sentiment.